### PR TITLE
Allow compilation out of tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ AS = $(CROSS_COMPILE)as
 LD = $(CROSS_COMPILE)ld
 OBJCOPY = $(CROSS_COMPILE)objcopy
 
-INCLUDES = -I $(PWD)/include -I $(PWD)/uboot-headers -ffreestanding
+INCLUDES = -I ./include -I ./uboot-headers -ffreestanding
 
 DEFINES = -DSOC_HEADER="\"h6.h\""
 

--- a/include/h6.h
+++ b/include/h6.h
@@ -1,5 +1,5 @@
-#ifndef _A64_H_
-#define _A64_H_
+#ifndef _H6_H_
+#define _H6_H_
 
 #define SOC_UART0		0x05000000
 


### PR DESCRIPTION
Hi @Icenowy ,

I'm adding your package to my buildroot and got an issue when building out of tree.

```c
/home/clement/buildroot/output/host/bin/aarch64-none-linux-gnu-gcc -I /home/clement/buildroot/include -I /home/clement/buildroot/uboot-headers -ffreestanding -DSOC_HEADER="\"h6.h\"" -DNDEBUG -D__ASSEMBLY__   -c -o start.o start.S
/home/clement/buildroot/output/host/bin/aarch64-none-linux-gnu-gcc -I /home/clement/buildroot/include -I /home/clement/buildroot/uboot-headers -ffreestanding -DSOC_HEADER="\"h6.h\"" -DNDEBUG -O2   -c -o init.o init.c
/home/clement/buildroot/output/host/bin/aarch64-none-linux-gnu-gcc -I /home/clement/buildroot/include -I /home/clement/buildroot/uboot-headers -ffreestanding -DSOC_HEADER="\"h6.h\"" -DNDEBUG -O2   -c -o uart.o uart.c
/home/clement/buildroot/output/host/bin/aarch64-none-linux-gnu-gcc -I /home/clement/buildroot/include -I /home/clement/buildroot/uboot-headers -ffreestanding -DSOC_HEADER="\"h6.h\"" -DNDEBUG -D__ASSEMBLY__   -c -o stack.o stack.S
/home/clement/buildroot/output/host/bin/aarch64-none-linux-gnu-gcc -I /home/clement/buildroot/include -I /home/clement/buildroot/uboot-headers -ffreestanding -DSOC_HEADER="\"h6.h\"" -DNDEBUG -D__ASSEMBLY__   -c -o exceptions.o exceptions.S
/home/clement/buildroot/output/host/bin/aarch64-none-linux-gnu-gcc -I /home/clement/buildroot/include -I /home/clement/buildroot/uboot-headers -ffreestanding -DSOC_HEADER="\"h6.h\"" -DNDEBUG -O2   -c -o exception_funcs.o exception_funcs.c
/home/clement/buildroot/output/host/bin/aarch64-none-linux-gnu-gcc -I /home/clement/buildroot/include -I /home/clement/buildroot/uboot-headers -ffreestanding -DSOC_HEADER="\"h6.h\"" -DNDEBUG -O2   -c -o panic.o panic.c
/home/clement/buildroot/output/host/bin/aarch64-none-linux-gnu-gcc -I /home/clement/buildroot/include -I /home/clement/buildroot/uboot-headers -ffreestanding -DSOC_HEADER="\"h6.h\"" -DNDEBUG -O2   -c -o pgtables.o pgtables.c
/home/clement/buildroot/output/host/bin/aarch64-none-linux-gnu-gcc -I /home/clement/buildroot/include -I /home/clement/buildroot/uboot-headers -ffreestanding -DSOC_HEADER="\"h6.h\"" -DNDEBUG -O2   -c -o trapped_funcs.o trapped_funcs.c
exceptions.S:7:10: fatal error: asm/macro.h: No such file or directory
    7 | #include <asm/macro.h>
      |          ^~~~~~~~~~~~~
compilation terminated.
<command-line>: fatal error: h6.h: No such file or directory
compilation terminated.
make[1]: *** [<builtin>: exceptions.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: *** [<builtin>: start.o] Error 1
<command-line>: fatal error: h6.h: No such file or directory
compilation terminated.
uart.c:1:10: fatal error: uart.h: No such file or directory
    1 | #include "uart.h"
      |          ^~~~~~~~
compilation terminated.
make[1]: *** [<builtin>: init.o] Error 1
make[1]: *** [<builtin>: uart.o] Error 1
<command-line>: fatal error: h6.h: No such file or directory
compilation terminated.
<command-line>: fatal error: h6.h: No such file or directory
compilation terminated.
<command-line>: fatal error: h6.h: No such file or directory
compilation terminated.
make[1]: *** [<builtin>: panic.o] Error 1
make[1]: *** [<builtin>: trapped_funcs.o] Error 1
make[1]: *** [<builtin>: exception_funcs.o] Error 1
<command-line>: fatal error: h6.h: No such file or directory
compilation terminated.
```