### PR TITLE
Fix build with recent toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DEFINES += -DNDEBUG
 endif
 
 ASFLAGS = $(INCLUDES) $(DEFINES) -D__ASSEMBLY__
-CFLAGS = $(INCLUDES) $(DEFINES) -O2
+CFLAGS = $(INCLUDES) $(DEFINES) -O2 -mno-outline-atomics -fno-stack-protector
 
 LDSCRIPT = ldscripts/a64.ld
 LDSCRIPTS = ldscripts/a64.ld ldscripts/common.ld

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ CFLAGS = $(INCLUDES) $(DEFINES) -O2
 LDSCRIPT = ldscripts/a64.ld
 LDSCRIPTS = ldscripts/a64.ld ldscripts/common.ld
 
-LDFLAGS = -nostdlib -nostartfiles -static -T $(LDSCRIPT)
+LDFLAGS = -nostdlib -static -T $(LDSCRIPT)
 
 OBJS = start.o init.o uart.o stack.o exceptions.o exception_funcs.o panic.o pgtables.o trapped_funcs.o
 


### PR DESCRIPTION
Hi,

Trying to retest the PCIe, but with a newer toolchain it doesn't compile anymore.

This fix issue #4